### PR TITLE
feat: import test course and libraries upon deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -124,6 +124,8 @@ jobs:
 
       - name: Import test course & libraries
         run: |
+          $SSH "#! /bin/bash -e
             git checkout https://github.com/openedx/openedx-test-course
             cd openedx-test-course
-            make import
+            make import TUTOR=$TUTOR
+          "

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -121,3 +121,9 @@ jobs:
           "
       - name: Import demo course
         run: $SSH "$TUTOR local importdemocourse"
+
+      - name: Import test course & libraries
+        run: |
+            git checkout https://github.com/openedx/openedx-test-course
+            cd openedx-test-course
+            make import


### PR DESCRIPTION
Import the latest version of the new [Open edX Test Course](https://github.com/openedx/openedx-test-course) into the Nutmeg demo instance every week. See the repository's README for details.

