### PR TITLE
fix: initialize codejail before quickstart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -110,6 +110,9 @@ jobs:
             # note: we removed the --no-cache option to avoid long deploy times
             $TUTOR images build all
           "
+      # Initialize codejail
+      - name: Init
+        run: $SSH "$TUTOR local init --limit=codejail"
       # Launch
       - name: Quickstart
         run: $SSH "$TUTOR local quickstart --non-interactive"


### PR DESCRIPTION
### Description
This PR initializes codejail before tutor quickstart as mentioned in [this](https://github.com/overhangio/nutmeg-demo/pull/15#issuecomment-1141460335) comment.